### PR TITLE
fix the "__lastmatch__" returns undefined

### DIFF
--- a/rivescript/sessions.py
+++ b/rivescript/sessions.py
@@ -189,10 +189,7 @@ class MemorySessionStorage(SessionManager):
         if not username in self._users:
             self._users[username] = self.default_session()
         for key, value in vars.items():
-            if value is None:
-                self._users[username].pop(key, None)
-            else:
-                self._users[username][key] = value
+            self._users[username][key] = value 
 
     def get(self, username, key):
         if not username in self._users:


### PR DESCRIPTION
In earlier version, if the value of key "lastmatch" is None, the key-value pair is removed from the users dictionary. 
My fix remains the key-value pair even when value is None.